### PR TITLE
サムネイル画像のサイズが横長でも収まるようにした

### DIFF
--- a/addImage.js
+++ b/addImage.js
@@ -64,9 +64,15 @@ $(function () {
       }
 
       // load lgtm image
-      $('<div class="thumbnail" />')
-      .css("background-image", 'url(' + url + ')')
+      $('<img class="thumbnail"/>').attr('src', url)
       .appendTo(this)
+      .load(function() {
+        url = $(this).attr('src');
+        $('<div class="thumbnail" />')
+        .css("background-image", 'url(' + url + ')')
+        .appendTo($(this).parent());
+        $(this).remove();
+      })
       .error(function(){
         this.remove();
       })

--- a/addImage.js
+++ b/addImage.js
@@ -10,26 +10,47 @@ $(function () {
       var urls = $(this).attr("href").split("/");
       var url = "https://i.gyazo.com/"+urls[3];
 
-      if($(this).children('img[src^="'+url+'"]').length > 0){
+      if($(this).children('div').length > 0){
           return false;
       }
 
       // guess png
-      $('<img class="thumbnail" />')
-      .attr("src", url+".png")
+      var self = this;
+      $('<img class="thumbnail"/>').attr('src', url + '.png')
       .appendTo(this)
+      .load(function() {
+        url = $(this).attr('src');
+        $('<div class="thumbnail" />')
+        .css("background-image", 'url(' + url + ')')
+        .appendTo($(this).parent());
+        $(this).remove();
+      })
       .error(function(){
-          // guess jpg
-          url = $(this).attr("src").replace(".png", ".jpg");
-          $(this).attr("src", url)
+        // guess jpg
+        url = $(this).attr('src').replace(".png", ".jpg");
+        $(this).attr('src', url)
+        .load(function() {
+          url = $(this).attr('src');
+          $('<div class="thumbnail" />')
+          .css("background-image", 'url(' + url + ')')
+          .appendTo($(this).parent());
+          $(this).remove();
+        })
+        .error(function(){
+          // guess gif
+          url = $(this).attr('src').replace(".jpg", ".gif");
+          $(this).attr('src', url)
+          .load(function() {
+            url = $(this).attr('src');
+            $('<div class="thumbnail" />')
+            .css("background-image", 'url(' + url + ')')
+            .appendTo($(this).parent());
+            $(this).remove();
+          })
           .error(function(){
-              // guess gif
-              url = $(this).attr("src").replace(".jpg", ".gif");
-              $(this).attr("src", url)
-              .error(function(){
-                $(this).remove();
-              });
+            $(this).remove();
           });
+        });
       });
     });
 
@@ -38,13 +59,13 @@ $(function () {
       var urls = $(this).attr("href").split("/");
       var url = "http://lgtm.in/p/"+urls[4];
 
-      if($(this).children('img[src^="'+url+'"]').length > 0){
+      if($(this).children('div').length > 0){
           return false;
       }
 
       // load lgtm image
-      $('<img class="thumbnail" />')
-      .attr("src", url)
+      $('<div class="thumbnail" />')
+      .css("background-image", 'url(' + url + ')')
       .appendTo(this)
       .error(function(){
         this.remove();
@@ -58,7 +79,7 @@ $(function () {
     .find('a[href^="http://"], a[href^="https://"]')
     .each(function() {
       var url = $(this).attr("href");
-      if ($(this).children('img[src^="'+url+'"]').length > 0) {
+      if ($(this).children('div').length > 0) {
         return true;
       }
 
@@ -72,12 +93,12 @@ $(function () {
       var lgtm_reg = new RegExp('^http://lgtm\.in/p/', 'i');
       if (img_reg.test(url) || lgtm_reg.test(url)) {
         // absolute image(has extension or lgtm.in)
-        $('<img class="thumbnail" />').attr("src", url)
+        $('<div class="thumbnail" />').css("background-image", 'url(' + url + ')')
         .appendTo(this);
       }
       else {
         // guess image
-        $('<img class="thumbnail-no-extension" />').attr("src", url)
+        $('<div class="thumbnail-no-extension" />').css("background-image", 'url(' + url + ')')
         .appendTo(this)
         .error(function(){
           this.remove();

--- a/addImage.js
+++ b/addImage.js
@@ -102,20 +102,6 @@ $(function () {
         $('<div class="thumbnail" />').css("background-image", 'url(' + url + ')')
         .appendTo(this);
       }
-      else {
-        // guess image
-        $('<div class="thumbnail-no-extension" />').css("background-image", 'url(' + url + ')')
-        .appendTo(this)
-        .error(function(){
-          this.remove();
-        })
-        .bind("load", function(){
-          $(this).css("display", "block").show();
-          var height = $(this).height();
-          var top = $('#_timeLine').scrollTop();
-          $('#_timeLine').scrollTop(top + height, 'normal');
-        });
-      }
     });
   };
 });

--- a/style.css
+++ b/style.css
@@ -1,10 +1,14 @@
 img.thumbnail {
   display: block;
   height: 250px;
-  text-align: center;
+  width: 0px;
 }
-img.thumbnail-no-extension {
-  display: none;
-  max-height: 250px;
-  text-align: center;
+
+div.thumbnail {
+  display: block;
+  background-position: left;
+  background-repeat: no-repeat;
+  width: 600px;
+  height: 250px;
+  background-size: contain;
 }


### PR DESCRIPTION
issue：#1

imgでは横長画像に対応できないのでdivにした。imgで対応できない理由としては、タイムラインの調整をjs側で行わずDOMサイズで行っており、imgだとwidthを固定してしまうとアス比を考えるとheightが不定となってしまうため。js側でタイムラインを調整しない件だが、何度か試したがどうしてもタイムラインがずれてしまったため。
## 設計方針

height:250pxのimgタグを仕込み、loadできたらimgを削除しdivのbackground-imageで表示する。このやり方だと先にDOMにheight:250pxを仕込むため、タイムラインは崩れない。しかし、拡張子なしのURLは読み込めるかどうかわからないので、この方法を用いると画面更新のたびに無駄な余白が生まれ消えを繰り返してしまう。よって拡張子なしのURLは非対応とした。（gyazo, lgtm.inを除く）
